### PR TITLE
[Feat] #123 - 출고지시 상세 조회 시 id 값도 반환하도록 추가

### DIFF
--- a/src/main/java/com/werp/sero/shipping/query/dto/GIDetailResponseDTO.java
+++ b/src/main/java/com/werp/sero/shipping/query/dto/GIDetailResponseDTO.java
@@ -17,7 +17,7 @@ public class GIDetailResponseDTO {
 
     // 1. 기본 출고 지시 정보
     @Schema(description = "출고지시 ID (PK)", example = "1")
-    private int id;
+    private int giId;
 
     @Schema(description = "출고지시 번호", example = "GI-20251207-001")
     private String giCode;
@@ -45,11 +45,20 @@ public class GIDetailResponseDTO {
     private String recipientContact;
 
     // 3. 관련 주문 정보
+    @Schema(description = "수주 ID (PK)", example = "1")
+    private int soId;
+
     @Schema(description = "수주 번호", example = "SO-20251201-001")
     private String soCode;
 
+    @Schema(description = "납품서 ID (PK)", example = "1")
+    private int doId;
+
     @Schema(description = "납품서 번호", example = "DO-20251201-001")
     private String doCode;
+
+    @Schema(description = "고객사 ID (PK)", example = "1")
+    private int clientId;
 
     @Schema(description = "고객사명", example = "현대모비스")
     private String clientName;
@@ -58,6 +67,9 @@ public class GIDetailResponseDTO {
     private String shippedAt;
 
     // 4. 출고 창고 정보
+    @Schema(description = "출고 창고 ID (PK)", example = "1")
+    private int warehouseId;
+
     @Schema(description = "출고 창고명", example = "서울 본사 창고")
     private String warehouseName;
 
@@ -70,8 +82,14 @@ public class GIDetailResponseDTO {
     private List<GIDetailItemDTO> items;
 
     // 7. 결재 정보 (담당자 배정 이후)
+    @Schema(description = "결재 ID (PK)", example = "1")
+    private Integer approvalId;
+
     @Schema(description = "결재 코드", example = "APV-20251207-001")
     private String approvalCode;
+
+    @Schema(description = "기안자 ID (PK)", example = "1")
+    private int drafterId;
 
     @Schema(description = "기안자명", example = "김철수")
     private String drafterName;
@@ -84,6 +102,9 @@ public class GIDetailResponseDTO {
 
     @Schema(description = "기안자 직급", example = "사원")
     private String drafterRank;
+
+    @Schema(description = "출고 담당자 ID (PK)", example = "2")
+    private Integer managerId;
 
     @Schema(description = "출고 담당자명", example = "이영희")
     private String managerName;

--- a/src/main/resources/com/werp/sero/shipping/query/dao/GIMapper.xml
+++ b/src/main/resources/com/werp/sero/shipping/query/dao/GIMapper.xml
@@ -11,7 +11,7 @@
         <id property="giCode" column="gi_code"/>
 
         <!-- 기본 출고 지시 정보 -->
-        <result property="id" column="gi_id"/>
+        <result property="giId" column="gi_id"/>
         <result property="createdAt" column="created_at"/>
         <result property="scheduledAt" column="scheduled_at"/>
         <result property="status" column="status"/>
@@ -23,23 +23,30 @@
         <result property="recipientContact" column="recipient_contact"/>
 
         <!-- 관련 주문 정보 -->
+        <result property="soId" column="so_id"/>
         <result property="soCode" column="so_code"/>
+        <result property="doId" column="do_id"/>
         <result property="doCode" column="do_code"/>
+        <result property="clientId" column="client_id"/>
         <result property="clientName" column="client_name"/>
         <result property="shippedAt" column="shipped_at"/>
 
         <!-- 출고 창고 정보 -->
+        <result property="warehouseId" column="warehouse_id"/>
         <result property="warehouseName" column="warehouse_name"/>
 
         <!-- 특이사항 -->
         <result property="note" column="note"/>
 
         <!-- 결재 정보 -->
+        <result property="approvalId" column="approval_id"/>
         <result property="approvalCode" column="approval_code"/>
+        <result property="drafterId" column="drafter_id"/>
         <result property="drafterName" column="drafter_name"/>
         <result property="drafterDepartment" column="drafter_department"/>
         <result property="drafterPosition" column="drafter_position"/>
         <result property="drafterRank" column="drafter_rank"/>
+        <result property="managerId" column="manager_id"/>
         <result property="managerName" column="manager_name"/>
 
         <!-- 출고지시 품목 목록 (Collection) -->
@@ -86,23 +93,30 @@
             D.contact AS recipient_contact,
 
             /* 관련 주문 정보 */
+            B.id AS so_id,
             B.so_code,
+            K.id AS do_id,
             A.do_code,
+            C.id AS client_id,
             C.company_name AS client_name,
             B.shipped_at,
 
             /* 출고 창고 정보 */
+            E.id AS warehouse_id,
             E.name AS warehouse_name,
 
             /* 특이사항 */
             A.note,
 
             /* 결재 정보 */
+            L.id AS approval_id,
             A.approval_code,
+            F.id AS drafter_id,
             F.name AS drafter_name,
             P.dept_name AS drafter_department,
             Q.name AS drafter_position,
             R.name AS drafter_rank,
+            G.id AS manager_id,
             G.name AS manager_name,
 
             /* 품목 정보 */


### PR DESCRIPTION
## Pull Request
### ISSUE
- #123 

### Develop
출고 지시 상세 조회 시 id 값도 반환하도록 dto에 id 추가
- giId(출고지시서 ID)
- soId(주문 ID)
- doId (납품서 ID)
- clientId (고객사 ID)
- warehouseId (창고 ID)
- approvalId (결재 ID)
- drafterId (기안자 ID)
- managerId (출고 담당자 ID)

### Test
<img width="774" height="529" alt="image" src="https://github.com/user-attachments/assets/263dd955-7679-4fce-8422-17550440f4f1" />
