### PR TITLE
[Feat] #94 - 토큰 재발급 API 구현

### DIFF
--- a/src/main/java/com/werp/sero/auth/controller/AuthController.java
+++ b/src/main/java/com/werp/sero/auth/controller/AuthController.java
@@ -4,13 +4,18 @@ import com.werp.sero.auth.dto.LoginRequestDTO;
 import com.werp.sero.auth.dto.LoginResponseDTO;
 import com.werp.sero.auth.service.AuthService;
 import com.werp.sero.security.enums.Type;
+import com.werp.sero.security.principal.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -53,5 +58,25 @@ public class AuthController {
         authService.logout(request, response);
 
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "본사 직원용 토큰 재발급")
+    @PostMapping("/auth/reissue")
+    public ResponseEntity<LoginResponseDTO> reissueEmployee(@AuthenticationPrincipal final CustomUserDetails customUserDetails,
+                                                            @CookieValue(value = "refreshToken") final String refreshToken,
+                                                            final HttpServletResponse response) {
+        final LoginResponseDTO responseDTO = authService.reissue(customUserDetails, refreshToken, response);
+
+        return ResponseEntity.ok(responseDTO);
+    }
+
+    @Operation(summary = "고객사 직원용 토큰 재발급")
+    @PostMapping("/clients/auth/reissue")
+    public ResponseEntity<LoginResponseDTO> reissueClientEmployee(@AuthenticationPrincipal final CustomUserDetails customUserDetails,
+                                                                  @CookieValue(value = "refreshToken") final String refreshToken,
+                                                                  final HttpServletResponse response) {
+        final LoginResponseDTO responseDTO = authService.reissue(customUserDetails, refreshToken, response);
+
+        return ResponseEntity.ok(responseDTO);
     }
 }

--- a/src/main/java/com/werp/sero/auth/service/AuthService.java
+++ b/src/main/java/com/werp/sero/auth/service/AuthService.java
@@ -3,11 +3,16 @@ package com.werp.sero.auth.service;
 import com.werp.sero.auth.dto.LoginRequestDTO;
 import com.werp.sero.auth.dto.LoginResponseDTO;
 import com.werp.sero.security.enums.Type;
+import com.werp.sero.security.principal.CustomUserDetails;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.Authentication;
 
 public interface AuthService {
     LoginResponseDTO login(final LoginRequestDTO requestDTO, final HttpServletResponse response, final Type type);
 
     void logout(final HttpServletRequest request, final HttpServletResponse response);
+
+    LoginResponseDTO reissue(final CustomUserDetails customUserDetails, final String refreshToken,
+                             final HttpServletResponse response);
 }


### PR DESCRIPTION
## Pull Request
### ISSUE
- #94 

### Develop
- 토큰 재발급 API 구현 `/clients/auth/reissue`, `/auth/reissue`

### Test

**토큰 재발급 API**

> POST /clients/auth/reissue(고객사 직원용) /auth/reissue(본사 직원용)

```
{
  "accessToken": "eyJhbGciOiJIUzM4NCJ9.eyJzdWIiOiJhZG1pbkB3ZXJwLmNvbSIsImF1dGgiOiJBQ19TWVMsQUNfU0FMLEFDX1dIUyIsImV4cCI6MTc2NzExMTk5MiwicG9zIjoiSlBfQ0VPIiwicmFuayI6IkpSX0NFTyIsImRlcHQiOiJERVBUX1dIU18xIiwiaWQiOjF9.BQpAj-hrFG2IPqyUmxjHP0jXV4gNl7bGGlobz9mPEit_-h0_KPsPds5vqJ28wTIb",
  "grantType": "Bearer",
  "permissions": "AC_SYS,AC_SAL,AC_WHS",
  "name": "김새로"
}
```
- 쿠키에 RefreshToken이 없거나 Redis에 RefreshToken 없을 경우 `ExpiredTokenException` 만료된 토큰 예외 발생
- 쿠키에 있는 RefreshToken 값과 Redis에 있는 RefreshToken 불일치 시 `InvalidTokenException` 유효하지 않는 토큰 예외 발생

