### PR TITLE
[Fix] #190 - 고객사 전용 거래가능 품목 조회 기능 추가

### DIFF
--- a/src/main/java/com/werp/sero/client/query/controller/ClientPortalQueryController.java
+++ b/src/main/java/com/werp/sero/client/query/controller/ClientPortalQueryController.java
@@ -1,7 +1,10 @@
 package com.werp.sero.client.query.controller;
 
 import com.werp.sero.client.query.dto.ClientDetailResponseDTO;
+import com.werp.sero.client.query.dto.ClientItemPriceHistoryResponseDTO;
+import com.werp.sero.client.query.dto.ClientItemResponseDTO;
 import com.werp.sero.client.query.dto.ClientPortalDetailResponseDTO;
+import com.werp.sero.client.query.service.ClientItemQueryService;
 import com.werp.sero.client.query.service.ClientQueryService;
 import com.werp.sero.employee.command.domain.aggregate.ClientEmployee;
 import com.werp.sero.security.annotation.CurrentUser;
@@ -9,10 +12,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "고객포털 관련 API", description = "고객포털 관련 API")
 @RequestMapping("/clients/{clientId}")
@@ -20,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class ClientPortalQueryController {
     private final ClientQueryService clientQueryService;
+    private final ClientItemQueryService clientItemQueryService;
 
     @Operation(summary = "고객사 상세 조회", description = "고객사 자신의 상세 정보를 조회합니다. (기본정보, 담당자, 여신)")
     @GetMapping("/details")
@@ -28,5 +31,27 @@ public class ClientPortalQueryController {
     ) {
         ClientPortalDetailResponseDTO client = clientQueryService.getClientDetailForClient(clientId);
         return ResponseEntity.ok(client);
+    }
+
+    @Operation(summary = "고객사 거래 가능 품목 조회")
+    @GetMapping("/items")
+    public ResponseEntity<List<ClientItemResponseDTO>> getClientItems(
+            @PathVariable int clientId,
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String status
+    ) {
+        List<ClientItemResponseDTO> items = clientItemQueryService.getClientItems(clientId, keyword, status);
+        return ResponseEntity.ok(items);
+    }
+
+    @Operation(summary = "고객사 가격 변동 이력 조회")
+    @GetMapping("/items/{itemId}/price-history")
+    public ResponseEntity<List<ClientItemPriceHistoryResponseDTO>> getPriceHistory(
+            @PathVariable int clientId,
+            @PathVariable int itemId
+    ) {
+        List<ClientItemPriceHistoryResponseDTO> history =
+                clientItemQueryService.getPriceHistory(clientId, itemId);
+        return ResponseEntity.ok(history);
     }
 }


### PR DESCRIPTION
## Pull Request
### ISSUE
- #190 

### Develop
기존: 본사용 고객사 관리를 위해 url이 clients-manage/items 로 되어 고객포털에서 접근 불가
수정: 고객사 전용 컨트롤러에서 clients/{clientId}/items로 기존의 서비스 호출하여 고객사에서 접근 가능하도록 수정
